### PR TITLE
Audio playback events from HTML5 & pepper API

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -136,7 +136,7 @@ deps = {
   'src/third_party/WebKit': 'https://github.com/nwjs/blink.git@origin/nw12',
 
   'src/third_party/node': 'https://github.com/nwjs/node.git@origin/nw12',
-  'src/content/nw': 'https://github.com/nwjs/nw.js.git@origin/master',
+  'src/content/nw': 'https://github.com/mohamed--abdel-maksoud/nw.js.git@origin/master',
 
   'src/third_party/icu':
    Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '51c1a4ce5f362676aa1f1cfdb5b7e52edabfa5aa',

--- a/content/renderer/pepper/pepper_platform_audio_output.cc
+++ b/content/renderer/pepper/pepper_platform_audio_output.cc
@@ -41,6 +41,7 @@ PepperPlatformAudioOutput* PepperPlatformAudioOutput::Create(
 }
 
 bool PepperPlatformAudioOutput::StartPlayback() {
+  printf ("\033[34m" "PepperPlatformAudioOutput::StartPlayback" "\033[0m\n");
   if (ipc_) {
     io_message_loop_proxy_->PostTask(
         FROM_HERE,

--- a/content/renderer/pepper/ppb_audio_impl.cc
+++ b/content/renderer/pepper/ppb_audio_impl.cc
@@ -19,6 +19,11 @@
 #include "ppapi/thunk/ppb_audio_config_api.h"
 #include "ppapi/thunk/thunk.h"
 
+// mohamed: my includes
+#include "third_party/WebKit/public/web/WebScriptSource.h"
+#include "third_party/WebKit/public/web/WebConsoleMessage.h"
+
+
 using ppapi::PpapiGlobals;
 using ppapi::thunk::EnterResourceNoLock;
 using ppapi::thunk::PPB_Audio_API;
@@ -53,6 +58,17 @@ PP_Resource PPB_Audio_Impl::GetCurrentConfig() {
 }
 
 PP_Bool PPB_Audio_Impl::StartPlayback() {
+  printf ("\033[34m" "content/renderer/pepper: Audio::StartPlayback" "\033[0m\n");
+  PepperPluginInstanceImpl* instance = static_cast<PepperPluginInstanceImpl*>(
+      PepperPluginInstance::Get(pp_instance()));
+  
+  const std::string js = "alert('::audio::start-playing');";
+  base::char16 js16[256];
+  unsigned int i;
+  for(i=0; i<js.size(); i++) js16[i] = js[i];
+  js16[i] = 0;
+  instance->render_frame()->ExecuteJavaScript(js16);
+  
   if (!audio_)
     return PP_FALSE;
   if (playing())
@@ -62,6 +78,17 @@ PP_Bool PPB_Audio_Impl::StartPlayback() {
 }
 
 PP_Bool PPB_Audio_Impl::StopPlayback() {
+  printf ("\033[34m" "content/renderer/pepper: Audio::StopPlayback" "\033[0m\n");
+  PepperPluginInstanceImpl* instance = static_cast<PepperPluginInstanceImpl*>(
+      PepperPluginInstance::Get(pp_instance()));
+  
+  const std::string js = "alert('::audio::stop-playing');";
+  base::char16 js16[256];
+  unsigned int i;
+  for(i=0; i<js.size(); i++) js16[i] = js[i];
+  js16[i] = 0;
+  instance->render_frame()->ExecuteJavaScript(js16);
+  
   if (!audio_)
     return PP_FALSE;
   if (!playing())

--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -1811,6 +1811,8 @@ blink::WebMediaPlayer* RenderFrameImpl::createMediaPlayer(
     const blink::WebURL& url,
     blink::WebMediaPlayerClient* client,
     blink::WebContentDecryptionModule* initial_cdm) {
+    
+    printf ("\033[34m" "createMediaPlayer called" "\033[0m\n");
 #if defined(VIDEO_HOLE)
   if (!contains_media_player_) {
     render_view_->RegisterVideoHoleFrame(this);
@@ -4201,6 +4203,7 @@ void RenderFrameImpl::InitializeUserMediaClient() {
 WebMediaPlayer* RenderFrameImpl::CreateWebMediaPlayerForMediaStream(
     const blink::WebURL& url,
     WebMediaPlayerClient* client) {
+    printf ("\033[34m" "CreateWebMediaPlayerForMediaStream called" "\033[0m\n");
 #if defined(ENABLE_WEBRTC)
 #if defined(OS_ANDROID) && defined(ARCH_CPU_ARMEL)
   bool found_neon =

--- a/extensions/browser/guest_view/web_view/web_view_guest.cc
+++ b/extensions/browser/guest_view/web_view/web_view_guest.cc
@@ -246,6 +246,10 @@ void WebViewGuest::CreateWebContents(
         base::UserMetricsAction("BadMessageTerminate_BPGM"));
     owner_render_process_host->Shutdown(content::RESULT_CODE_KILLED_BAD_MESSAGE,
                                         false);
+    
+    printf ("\033[34m" "WebViewGuest::CreateWebContents" "\033[0m\n");
+    
+    
     callback.Run(NULL);
     return;
   }

--- a/media/blink/webmediaplayer_impl.cc
+++ b/media/blink/webmediaplayer_impl.cc
@@ -54,7 +54,7 @@
 
 // mohamed: my includes
 #include "third_party/WebKit/public/web/WebScriptSource.h"
-#include "third_party/WebKit/public/web/WebConsoleMessage.h"
+
 
 using blink::WebCanvas;
 using blink::WebMediaPlayer;
@@ -150,6 +150,8 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
           client,
           base::Bind(&WebMediaPlayerImpl::SetCdm, AsWeakPtr())),
       renderer_factory_(renderer_factory.Pass()) {
+
+  printf ("\033[34m" "WebMediaPlayerImpl::constructor called" "\033[0m\n");
   // Threaded compositing isn't enabled universally yet.
   if (!compositor_task_runner_.get())
     compositor_task_runner_ = base::MessageLoopProxy::current();
@@ -176,11 +178,7 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
 WebMediaPlayerImpl::~WebMediaPlayerImpl() {
     
     
-  blink::WebString message(
-      blink::WebString::fromUTF8("WebMediaPlayerImpl::~"));
-  frame_->addMessageToConsole(blink::WebConsoleMessage(
-      blink::WebConsoleMessage::LevelDebug, message));
-  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('stop-playing', { 'detail': 0 }) );");
+  const blink::WebString js = blink::WebString("alert('::audio::stop-playing');");
   frame_->executeScript(blink::WebScriptSource(js));
   
   client_->setWebLayer(NULL);
@@ -214,6 +212,8 @@ WebMediaPlayerImpl::~WebMediaPlayerImpl() {
 
 void WebMediaPlayerImpl::load(LoadType load_type, const blink::WebURL& url,
                               CORSMode cors_mode) {
+  
+  printf ("\033[34m" "WebMediaPlayerImpl::load(%s) called" "\033[0m\n", url.spec().data());
   DVLOG(1) << __FUNCTION__ << "(" << load_type << ", " << url << ", "
            << cors_mode << ")";
   if (!defer_load_cb_.is_null()) {
@@ -227,6 +227,9 @@ void WebMediaPlayerImpl::load(LoadType load_type, const blink::WebURL& url,
 void WebMediaPlayerImpl::DoLoad(LoadType load_type,
                                 const blink::WebURL& url,
                                 CORSMode cors_mode) {
+  
+  printf ("\033[34m" "WebMediaPlayerImpl::DoLoad(%s) called" "\033[0m\n", url.spec().data());
+  
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
   GURL gurl(url);
@@ -244,6 +247,7 @@ void WebMediaPlayerImpl::DoLoad(LoadType load_type,
   // Media source pipelines can start immediately.
   if (load_type == LoadTypeMediaSource) {
     supports_save_ = false;
+    printf ("\033[34m" "WebMediaPlayerImpl::DoLoad  load_type = LoadTypeMediaSource" "\033[0m\n");
     StartPipeline();
     return;
   }
@@ -263,16 +267,18 @@ void WebMediaPlayerImpl::DoLoad(LoadType load_type,
 }
 
 void WebMediaPlayerImpl::play() {
+  
+  printf ("\033[34m" "WebMediaPlayerImpl::play" "\033[0m\n");
+  
+  // TODO frame_->view(), 
+  // https://groups.google.com/a/chromium.org/forum/#!topic/chromium-apps/gOKDKDk99pQ
+  // https://groups.google.com/a/chromium.org/forum/#!topic/chromium-apps/gOKDKDk99pQ
+  
   DVLOG(1) << __FUNCTION__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
   
-  blink::WebString message(
-      blink::WebString::fromUTF8("WebMediaPlayerImpl::play"));
-  frame_->addMessageToConsole(blink::WebConsoleMessage(
-      blink::WebConsoleMessage::LevelDebug, message));
-  
-  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('start-playing', { 'detail': 0 }) );");
-  // TODO process id instead of 0, although not necessary
+  //const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('start-playing', { 'detail': 0 }) );");
+  const blink::WebString js = blink::WebString("alert('::audio::start-playing');");
   frame_->executeScript(blink::WebScriptSource(js));
 
   paused_ = false;
@@ -287,14 +293,13 @@ void WebMediaPlayerImpl::play() {
 }
 
 void WebMediaPlayerImpl::pause() {
+  
+  printf ("\033[34m" "WebMediaPlayerImpl::stop" "\033[0m\n");
+  
   DVLOG(1) << __FUNCTION__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
   
-  blink::WebString message(
-      blink::WebString::fromUTF8("WebMediaPlayerImpl::pause"));
-  frame_->addMessageToConsole(blink::WebConsoleMessage(
-      blink::WebConsoleMessage::LevelDebug, message));
-  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('stop-playing', { 'detail': 0 }) );");
+  const blink::WebString js = blink::WebString("alert('::audio::stop-playing');");
   frame_->executeScript(blink::WebScriptSource(js));
 
   const bool was_already_paused = paused_ || playback_rate_ == 0;
@@ -316,6 +321,9 @@ bool WebMediaPlayerImpl::supportsSave() const {
 }
 
 void WebMediaPlayerImpl::seek(double seconds) {
+  
+  printf ("\033[34m" "WebMediaPlayerImpl::seek(%0.2d)" "\033[0m\n", seconds);
+  
   DVLOG(1) << __FUNCTION__ << "(" << seconds << "s)";
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
@@ -874,6 +882,8 @@ void WebMediaPlayerImpl::NotifyDownloading(bool is_downloading) {
 }
 
 void WebMediaPlayerImpl::StartPipeline() {
+  printf ("\033[34m" "WebMediaPlayerImpl::StartPipeline" "\033[0m\n");
+  
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
   // Keep track if this is a MSE or non-MSE playback.

--- a/media/blink/webmediaplayer_impl.cc
+++ b/media/blink/webmediaplayer_impl.cc
@@ -52,6 +52,10 @@
 #include "third_party/WebKit/public/web/WebSecurityOrigin.h"
 #include "third_party/WebKit/public/web/WebView.h"
 
+// mohamed: my includes
+#include "third_party/WebKit/public/web/WebScriptSource.h"
+#include "third_party/WebKit/public/web/WebConsoleMessage.h"
+
 using blink::WebCanvas;
 using blink::WebMediaPlayer;
 using blink::WebRect;
@@ -170,6 +174,15 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
 }
 
 WebMediaPlayerImpl::~WebMediaPlayerImpl() {
+    
+    
+  blink::WebString message(
+      blink::WebString::fromUTF8("WebMediaPlayerImpl::~"));
+  frame_->addMessageToConsole(blink::WebConsoleMessage(
+      blink::WebConsoleMessage::LevelDebug, message));
+  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('stop-playing', { 'detail': 0 }) );");
+  frame_->executeScript(blink::WebScriptSource(js));
+  
   client_->setWebLayer(NULL);
 
   DCHECK(main_task_runner_->BelongsToCurrentThread());
@@ -252,6 +265,15 @@ void WebMediaPlayerImpl::DoLoad(LoadType load_type,
 void WebMediaPlayerImpl::play() {
   DVLOG(1) << __FUNCTION__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
+  
+  blink::WebString message(
+      blink::WebString::fromUTF8("WebMediaPlayerImpl::play"));
+  frame_->addMessageToConsole(blink::WebConsoleMessage(
+      blink::WebConsoleMessage::LevelDebug, message));
+  
+  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('start-playing', { 'detail': 0 }) );");
+  // TODO process id instead of 0, although not necessary
+  frame_->executeScript(blink::WebScriptSource(js));
 
   paused_ = false;
   pipeline_.SetPlaybackRate(playback_rate_);
@@ -267,6 +289,13 @@ void WebMediaPlayerImpl::play() {
 void WebMediaPlayerImpl::pause() {
   DVLOG(1) << __FUNCTION__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
+  
+  blink::WebString message(
+      blink::WebString::fromUTF8("WebMediaPlayerImpl::pause"));
+  frame_->addMessageToConsole(blink::WebConsoleMessage(
+      blink::WebConsoleMessage::LevelDebug, message));
+  const blink::WebString js = blink::WebString("window.dispatchEvent( new CustomEvent('stop-playing', { 'detail': 0 }) );");
+  frame_->executeScript(blink::WebScriptSource(js));
 
   const bool was_already_paused = paused_ || playback_rate_ == 0;
   paused_ = true;

--- a/ppapi/cpp/audio.cc
+++ b/ppapi/cpp/audio.cc
@@ -27,6 +27,7 @@ Audio::Audio(const InstanceHandle& instance,
              void* user_data)
     : config_(config),
       use_1_0_interface_(false) {
+  printf ("\033[34m" "Audio::Audio v1" "\033[0m\n");
   if (has_interface<PPB_Audio_1_1>()) {
     PassRefFromConstructor(get_interface<PPB_Audio_1_1>()->Create(
         instance.pp_instance(), config.pp_resource(), callback, user_data));
@@ -39,6 +40,7 @@ Audio::Audio(const InstanceHandle& instance,
              void* user_data)
     : config_(config),
       use_1_0_interface_(true) {
+  printf ("\033[34m" "Audio::Audio v2" "\033[0m\n");
   if (has_interface<PPB_Audio_1_0>()) {
     PassRefFromConstructor(get_interface<PPB_Audio_1_0>()->Create(
         instance.pp_instance(), config.pp_resource(), callback, user_data));
@@ -46,6 +48,9 @@ Audio::Audio(const InstanceHandle& instance,
 }
 
 bool Audio::StartPlayback() {
+  
+  printf ("\033[34m" "Audio::StartPlayback" "\033[0m\n");
+  
   if (has_interface<PPB_Audio_1_1>() && !use_1_0_interface_) {
     return PP_ToBool(get_interface<PPB_Audio_1_1>()->StartPlayback(
         pp_resource()));
@@ -58,6 +63,7 @@ bool Audio::StartPlayback() {
 }
 
 bool Audio::StopPlayback() {
+  printf ("\033[34m" "Audio::StopPlayback" "\033[0m\n");
   if (has_interface<PPB_Audio_1_1>() && !use_1_0_interface_) {
     return PP_ToBool(get_interface<PPB_Audio_1_1>()->StopPlayback(
         pp_resource()));

--- a/ppapi/proxy/ppb_audio_proxy.cc
+++ b/ppapi/proxy/ppb_audio_proxy.cc
@@ -93,6 +93,7 @@ PP_Resource Audio::GetCurrentConfig() {
 }
 
 PP_Bool Audio::StartPlayback() {
+  printf ("\033[34m" "proxy::Audio::StartPlayback" "\033[0m\n");
   if (playing())
     return PP_TRUE;
   if (!PPB_Audio_Shared::IsThreadFunctionReady())
@@ -105,6 +106,7 @@ PP_Bool Audio::StartPlayback() {
 }
 
 PP_Bool Audio::StopPlayback() {
+  printf ("\033[34m" "proxy::Audio::StopPlayback" "\033[0m\n");
   if (!playing())
     return PP_TRUE;
   PluginDispatcher::GetForResource(this)->Send(

--- a/remoting/client/plugin/pepper_audio_player.cc
+++ b/remoting/client/plugin/pepper_audio_player.cc
@@ -55,6 +55,7 @@ bool PepperAudioPlayer::ResetAudioPlayer(
 
   // Immediately start the player.
   bool success = audio_.StartPlayback();
+  LOG(ERROR) << "remoting::ResetAudioPlayer called";
   if (!success)
     LOG(ERROR) << "Failed to start Pepper audio player";
   return success;


### PR DESCRIPTION
A modification to send events from webviews for audio playback events (start and stop). We make use of the "dialog" event with special arguments to communicate to the parent frame.
Development is generously sponsored by Seznam (https://www.seznam.cz)