### PR TITLE
Fixed issue of restored window size on Windows 8/10

### DIFF
--- a/chrome/browser/ui/views/apps/chrome_native_app_window_views_win.cc
+++ b/chrome/browser/ui/views/apps/chrome_native_app_window_views_win.cc
@@ -145,11 +145,6 @@ views::NonClientFrameView*
 ChromeNativeAppWindowViewsWin::CreateStandardDesktopAppFrame() {
   glass_frame_view_ = NULL;
 
-  const extensions::Extension* extension = app_window()->GetExtension();
-  if (extension && extension->is_nwjs_app())
-    return ChromeNativeAppWindowViewsAura::CreateStandardDesktopAppFrame();
-  //return new views::NativeFrameView(widget());
-
   if (ui::win::IsAeroGlassEnabled()) {
     glass_frame_view_ = new GlassAppWindowFrameViewWin(this, widget());
     return glass_frame_view_;


### PR DESCRIPTION
This fix reverted part of previous fix for menu support, which is
not necessary and buggy on the size calculation on Windows 8/10.
Current menu implementation on Windows is the same as Linux based
on Aura views.

Fixed nwjs/nw.js#4323