### PR TITLE
[win] fix menubar background

### DIFF
--- a/ui/native_theme/native_theme_win.cc
+++ b/ui/native_theme/native_theme_win.cc
@@ -50,6 +50,7 @@ const int kSystemColors[] = {
   COLOR_HIGHLIGHT,
   COLOR_HIGHLIGHTTEXT,
   COLOR_HOTLIGHT,
+  COLOR_MENU,
   COLOR_MENUHIGHLIGHT,
   COLOR_SCROLLBAR,
   COLOR_WINDOW,
@@ -524,6 +525,10 @@ SkColor NativeThemeWin::GetSystemColor(ColorId color_id) const {
       return kButtonHighlightColor;
     case kColorId_ButtonHoverColor:
       return kButtonHoverColor;
+
+    // Menu
+    case kColorId_MenuBackgroundColor:
+      return system_colors_[COLOR_MENU];
 
     // Label
     case kColorId_LabelEnabledColor:

--- a/ui/views/controls/button/label_button.cc
+++ b/ui/views/controls/button/label_button.cc
@@ -493,6 +493,9 @@ void LabelButton::ResetColorsFromNativeTheme() {
 #endif
     label_->set_background(NULL);
   } else {
+    // Set auto color readability to false in case of switching theme from
+    // inverted color scheme.
+    label_->SetAutoColorReadabilityEnabled(false);
     label_->set_background(NULL);
   }
 


### PR DESCRIPTION
Menubar background should be consistent with the theme by the
system. On Windows, we use `COLOR_MENU` for the background color
for menubar.

fixed nwjs/nw.js#4851