### PR TITLE
activate window before showing dialogs

### DIFF
--- a/extensions/browser/app_window/app_window.cc
+++ b/extensions/browser/app_window/app_window.cc
@@ -528,6 +528,18 @@ bool AppWindow::PreHandleGestureEvent(WebContents* source,
   return AppWebContentsHelper::ShouldSuppressGestureEvent(event);
 }
 
+// Fix for issue https://github.com/nwjs/nw.js/issues/4992
+// Bounds of dialogs are calcuated based on the bounds of parent window.
+// However on Windows, when window is minized, the bounds returned from system
+// is empty.
+// Implementing `WebContentsDelegate::ActivateContents` in `AppWindow` to
+// activate the native window before showing dialog fixes the issue.
+void AppWindow::ActivateContents(content::WebContents* contents) {
+  // Only activate window for NW.js app to avoid side effects to Chrome Apps.
+  if (GetExtension()->is_nwjs_app())
+    native_app_window_->Activate();
+}
+
 void AppWindow::RenderViewCreated(content::RenderViewHost* render_view_host) {
   app_delegate_->RenderViewCreated(render_view_host);
 }

--- a/extensions/browser/app_window/app_window.h
+++ b/extensions/browser/app_window/app_window.h
@@ -458,6 +458,7 @@ class AppWindow : public content::WebContentsDelegate,
                           bool last_unlocked_by_target) override;
   bool PreHandleGestureEvent(content::WebContents* source,
                              const blink::WebGestureEvent& event) override;
+  void ActivateContents(content::WebContents* contents) override;
 
   // content::WebContentsObserver implementation.
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;


### PR DESCRIPTION
Bounds of dialogs are calcuated based on the bounds of parent window.
However on Windows, when window is minized, the bounds returned from
system is empty.
Implementing `WebContentsDelegate::ActivateContents` in `AppWindow` to
activate the native window before showing dialog fixes the issue.

fixed nwjs/nw.js#4992

backport from PR #30