### PR TITLE
[linux] enabled global menubar on Ubuntu

### DIFF
--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
@@ -56,14 +56,17 @@ void BrowserDesktopWindowTreeHostX11::Init(
     aura::Window* content_window,
     const views::Widget::InitParams& params) {
   views::DesktopWindowTreeHostX11::Init(content_window, params);
-
+#if 0
   // We have now created our backing X11 window. We now need to (possibly)
   // alert Unity that there's a menu bar attached to it.
   global_menu_bar_x11_.reset(new GlobalMenuBarX11(browser_view_, this));
+#endif
 }
 
 void BrowserDesktopWindowTreeHostX11::CloseNow() {
+#if 0
   global_menu_bar_x11_.reset();
+#endif
   DesktopWindowTreeHostX11::CloseNow();
 }
 

--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
@@ -7,7 +7,9 @@
 
 #include "base/macros.h"
 #include "chrome/browser/ui/views/frame/browser_desktop_window_tree_host.h"
+#if 0
 #include "chrome/browser/ui/views/frame/global_menu_bar_x11.h"
+#endif
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
 
 class BrowserFrame;
@@ -40,12 +42,12 @@ class BrowserDesktopWindowTreeHostX11
   void CloseNow() override;
 
   BrowserView* browser_view_;
-
+#if 0
   // Each browser frame maintains its own menu bar object because the lower
   // level dbus protocol associates a xid to a menu bar; we can't map multiple
   // xids to the same menu bar.
   scoped_ptr<GlobalMenuBarX11> global_menu_bar_x11_;
-
+#endif
   DISALLOW_COPY_AND_ASSIGN(BrowserDesktopWindowTreeHostX11);
 };
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -57,6 +57,8 @@
 #include "ui/wm/core/compound_event_filter.h"
 #include "ui/wm/core/window_util.h"
 
+#include "content/nw/src/browser/global_menu_bar_x11.h"
+
 DECLARE_WINDOW_PROPERTY_TYPE(views::DesktopWindowTreeHostX11*);
 
 namespace content {
@@ -353,6 +355,7 @@ void DesktopWindowTreeHostX11::Close() {
 }
 
 void DesktopWindowTreeHostX11::CloseNow() {
+  global_menu_bar_x11_.reset();
   if (xwindow_ == None)
     return;
 
@@ -2043,6 +2046,16 @@ ui::NativeTheme* DesktopWindowTreeHost::GetNativeTheme(aura::Window* window) {
   }
 
   return ui::NativeThemeAura::instance();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostX11, public:
+// NW fix
+
+void DesktopWindowTreeHostX11::SetGlobalMenu(ui::MenuModel* model) {
+  global_menu_bar_x11_.reset(model ?
+                               new nw::GlobalMenuBarX11(this, model) :
+                               nullptr);
 }
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
@@ -32,6 +32,11 @@ class ImageSkiaRep;
 
 namespace ui {
 class EventHandler;
+class MenuModel;
+}
+
+namespace nw {
+class GlobalMenuBarX11;
 }
 
 namespace views {
@@ -85,6 +90,11 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Runs the |func| callback for each content-window, and deallocates the
   // internal list of open windows.
   static void CleanUpWindowList(void (*func)(aura::Window* window));
+
+  void SetGlobalMenu(ui::MenuModel *model);
+
+  // NW fix: expose GetAccleratedWidget
+  gfx::AcceleratedWidget GetAcceleratedWidget() override;
 
  protected:
   // Overridden from DesktopWindowTreeHost:
@@ -151,7 +161,6 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Overridden from aura::WindowTreeHost:
   gfx::Transform GetRootTransform() const override;
   ui::EventSource* GetEventSource() override;
-  gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void ShowImpl() override;
   void HideImpl() override;
   gfx::Rect GetBounds() const override;
@@ -347,6 +356,8 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   bool activatable_;
 
   base::CancelableCallback<void()> delayed_resize_task_;
+
+  std::unique_ptr<nw::GlobalMenuBarX11> global_menu_bar_x11_;
 
   base::WeakPtrFactory<DesktopWindowTreeHostX11> close_widget_factory_;
 


### PR DESCRIPTION
Exposed APIs for global menubar on Ubuntu. This patch also removed
global menubar for DevTools window.

fixed partially on nwjs/nw.js#2718
backport for NW14