### PR TITLE
only send original arguments to singleton process

### DIFF
--- a/chrome/browser/process_singleton_posix.cc
+++ b/chrome/browser/process_singleton_posix.cc
@@ -868,8 +868,10 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
   if (!PathService::Get(base::DIR_CURRENT, &current_dir))
     return PROCESS_NONE;
   to_send.append(current_dir.value());
-
-  const std::vector<std::string>& argv = cmd_line.argv();
+  
+  // NW fix: only send original arguments to singleton process.
+  // issue: nwjs/nw.js#2068
+  const std::vector<std::string>& argv = cmd_line.original_argv();
   for (std::vector<std::string>::const_iterator it = argv.begin();
       it != argv.end(); ++it) {
     to_send.push_back(kTokenDelimiter);

--- a/chrome/browser/win/chrome_process_finder.cc
+++ b/chrome/browser/win/chrome_process_finder.cc
@@ -44,6 +44,7 @@ NotifyChromeResult AttemptToNotifyRunningChrome(HWND remote_window,
   if (!thread_id || !process_id)
     return NOTIFY_FAILED;
 
+#if 0
   base::CommandLine command_line(*base::CommandLine::ForCurrentProcess());
   command_line.AppendSwitchASCII(
       switches::kOriginalProcessStartTime,
@@ -52,7 +53,11 @@ NotifyChromeResult AttemptToNotifyRunningChrome(HWND remote_window,
 
   if (fast_start)
     command_line.AppendSwitch(switches::kFastStart);
-
+#endif
+  
+  // NW fix: only send original arguments to singleton process.
+  // issue: nwjs/nw.js#2068
+  base::CommandLine command_line(base::CommandLine::ForCurrentProcess()->original_argv());
   // Send the command line to the remote chrome window.
   // Format is "START\0<<<current directory>>>\0<<<commandline>>>".
   std::wstring to_send(L"START\0", 6);  // want the NULL in the string.


### PR DESCRIPTION
test case: test/sanity/app-open-event
fixed nwjs/nw.js#2068