### PR TITLE
[linux] enabled global menubar on Ubuntu

### DIFF
--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
@@ -21,8 +21,7 @@ BrowserDesktopWindowTreeHostX11::BrowserDesktopWindowTreeHostX11(
     BrowserView* browser_view,
     BrowserFrame* browser_frame)
     : DesktopWindowTreeHostX11(native_widget_delegate,
-                               desktop_native_widget_aura),
-      browser_view_(browser_view) {
+                               desktop_native_widget_aura) {
   browser_frame->set_frame_type(
       browser_frame->UseCustomFrame() ? views::Widget::FRAME_TYPE_FORCE_CUSTOM
                                       : views::Widget::FRAME_TYPE_FORCE_NATIVE);
@@ -56,14 +55,17 @@ void BrowserDesktopWindowTreeHostX11::Init(
     aura::Window* content_window,
     const views::Widget::InitParams& params) {
   views::DesktopWindowTreeHostX11::Init(content_window, params);
-
+#if 0
   // We have now created our backing X11 window. We now need to (possibly)
   // alert Unity that there's a menu bar attached to it.
   global_menu_bar_x11_.reset(new GlobalMenuBarX11(browser_view_, this));
+#endif
 }
 
 void BrowserDesktopWindowTreeHostX11::CloseNow() {
+#if 0
   global_menu_bar_x11_.reset();
+#endif
   DesktopWindowTreeHostX11::CloseNow();
 }
 

--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
@@ -7,7 +7,9 @@
 
 #include "base/macros.h"
 #include "chrome/browser/ui/views/frame/browser_desktop_window_tree_host.h"
+#if 0
 #include "chrome/browser/ui/views/frame/global_menu_bar_x11.h"
+#endif
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
 
 class BrowserFrame;
@@ -38,14 +40,14 @@ class BrowserDesktopWindowTreeHostX11
   void Init(aura::Window* content_window,
             const views::Widget::InitParams& params) override;
   void CloseNow() override;
-
+#if 0
   BrowserView* browser_view_;
 
   // Each browser frame maintains its own menu bar object because the lower
   // level dbus protocol associates a xid to a menu bar; we can't map multiple
   // xids to the same menu bar.
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_x11_;
-
+#endif
   DISALLOW_COPY_AND_ASSIGN(BrowserDesktopWindowTreeHostX11);
 };
 

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -123,6 +123,7 @@ component("views") {
       if (use_atk) {
         sources += gypi_values.views_desktop_aura_x11_sources
         configs += [ "//build/config/linux/atk" ]
+        deps += [ "//build/linux/libgio:libgio" ]
       } else if (is_win) {
         sources += gypi_values.views_desktop_aura_win_sources
       } else if (use_ozone) {

--- a/ui/views/views.gyp
+++ b/ui/views/views.gyp
@@ -475,6 +475,10 @@
       'widget/desktop_aura/x11_whole_screen_move_loop.h',
       'widget/desktop_aura/x11_window_event_filter.cc',
       'widget/desktop_aura/x11_window_event_filter.h',
+      '../../content/nw/src/browser/global_menu_bar_registrar_x11.cc',
+      '../../content/nw/src/browser/global_menu_bar_registrar_x11.h',
+      '../../content/nw/src/browser/global_menu_bar_x11.cc',
+      '../../content/nw/src/browser/global_menu_bar_x11.h',
     ],
     'views_desktop_aura_win_sources': [
       'widget/desktop_aura/desktop_cursor_loader_updater_aurawin.cc',
@@ -806,6 +810,7 @@
             ['use_x11 == 1', {
               'sources': [ '<@(views_desktop_aura_x11_sources)' ],
               'dependencies': [
+                '../../build/linux/system.gyp:gio',
                 '../../build/linux/system.gyp:xext',
                 '../../ui/base/x/ui_base_x.gyp:ui_base_x',
               ],

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -63,6 +63,8 @@
 #include "ui/wm/core/compound_event_filter.h"
 #include "ui/wm/core/window_util.h"
 
+#include "content/nw/src/browser/global_menu_bar_x11.h"
+
 DECLARE_WINDOW_PROPERTY_TYPE(views::DesktopWindowTreeHostX11*);
 
 namespace content {
@@ -359,6 +361,7 @@ void DesktopWindowTreeHostX11::Close() {
 }
 
 void DesktopWindowTreeHostX11::CloseNow() {
+  global_menu_bar_x11_.reset();
   if (xwindow_ == None)
     return;
 
@@ -2102,6 +2105,16 @@ ui::NativeTheme* DesktopWindowTreeHost::GetNativeTheme(aura::Window* window) {
   }
 
   return ui::NativeThemeAura::instance();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostX11, public:
+// NW fix
+
+void DesktopWindowTreeHostX11::SetGlobalMenu(ui::MenuModel* model) {
+  global_menu_bar_x11_.reset(model ?
+                               new nw::GlobalMenuBarX11(this, model) :
+                               nullptr);
 }
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
@@ -32,6 +32,11 @@ class ImageSkiaRep;
 
 namespace ui {
 class EventHandler;
+class MenuModel;
+}
+
+namespace nw {
+class GlobalMenuBarX11;
 }
 
 namespace views {
@@ -85,6 +90,11 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Runs the |func| callback for each content-window, and deallocates the
   // internal list of open windows.
   static void CleanUpWindowList(void (*func)(aura::Window* window));
+
+  void SetGlobalMenu(ui::MenuModel *model);
+
+  // NW fix: expose GetAccleratedWidget
+  gfx::AcceleratedWidget GetAcceleratedWidget() override;
 
  protected:
   // Overridden from DesktopWindowTreeHost:
@@ -153,7 +163,6 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Overridden from aura::WindowTreeHost:
   gfx::Transform GetRootTransform() const override;
   ui::EventSource* GetEventSource() override;
-  gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void ShowImpl() override;
   void HideImpl() override;
   gfx::Rect GetBounds() const override;
@@ -359,6 +368,8 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   bool activatable_;
 
   base::CancelableCallback<void()> delayed_resize_task_;
+
+  std::unique_ptr<nw::GlobalMenuBarX11> global_menu_bar_x11_;
 
   base::WeakPtrFactory<DesktopWindowTreeHostX11> close_widget_factory_;
 


### PR DESCRIPTION
Exposed APIs for global menubar on Ubuntu. This patch also removed
global menubar for DevTools window.

fixed partially on nwjs/nw.js#2718