### PR TITLE
[linux] enabled global menubar on Ubuntu

### DIFF
--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.cc
@@ -21,8 +21,7 @@ BrowserDesktopWindowTreeHostX11::BrowserDesktopWindowTreeHostX11(
     BrowserView* browser_view,
     BrowserFrame* browser_frame)
     : DesktopWindowTreeHostX11(native_widget_delegate,
-                               desktop_native_widget_aura),
-      browser_view_(browser_view) {
+                               desktop_native_widget_aura) {
   browser_frame->set_frame_type(
       browser_frame->UseCustomFrame() ? views::Widget::FRAME_TYPE_FORCE_CUSTOM
                                       : views::Widget::FRAME_TYPE_FORCE_NATIVE);
@@ -56,14 +55,17 @@ void BrowserDesktopWindowTreeHostX11::Init(
     aura::Window* content_window,
     const views::Widget::InitParams& params) {
   views::DesktopWindowTreeHostX11::Init(content_window, params);
-
+#if 0
   // We have now created our backing X11 window. We now need to (possibly)
   // alert Unity that there's a menu bar attached to it.
   global_menu_bar_x11_.reset(new GlobalMenuBarX11(browser_view_, this));
+#endif
 }
 
 void BrowserDesktopWindowTreeHostX11::CloseNow() {
+#if 0
   global_menu_bar_x11_.reset();
+#endif
   DesktopWindowTreeHostX11::CloseNow();
 }
 

--- a/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
+++ b/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_x11.h
@@ -7,7 +7,9 @@
 
 #include "base/macros.h"
 #include "chrome/browser/ui/views/frame/browser_desktop_window_tree_host.h"
+#if 0
 #include "chrome/browser/ui/views/frame/global_menu_bar_x11.h"
+#endif
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
 
 class BrowserFrame;
@@ -38,14 +40,14 @@ class BrowserDesktopWindowTreeHostX11
   void Init(aura::Window* content_window,
             const views::Widget::InitParams& params) override;
   void CloseNow() override;
-
+#if 0
   BrowserView* browser_view_;
 
   // Each browser frame maintains its own menu bar object because the lower
   // level dbus protocol associates a xid to a menu bar; we can't map multiple
   // xids to the same menu bar.
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_x11_;
-
+#endif
   DISALLOW_COPY_AND_ASSIGN(BrowserDesktopWindowTreeHostX11);
 };
 

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -588,6 +588,10 @@ component("views") {
           "widget/desktop_aura/x11_whole_screen_move_loop.h",
           "widget/desktop_aura/x11_window_event_filter.cc",
           "widget/desktop_aura/x11_window_event_filter.h",
+          "../../content/nw/src/browser/global_menu_bar_registrar_x11.cc",
+          "../../content/nw/src/browser/global_menu_bar_registrar_x11.h",
+          "../../content/nw/src/browser/global_menu_bar_x11.cc",
+          "../../content/nw/src/browser/global_menu_bar_x11.h",
         ]
         if (use_atk) {
           sources += [
@@ -595,6 +599,7 @@ component("views") {
             "accessibility/native_view_accessibility_auralinux.h",
           ]
           configs += [ "//build/config/linux/atk" ]
+          deps += [ "//build/linux/libgio:libgio" ]
         }
       } else if (is_win) {
         sources += [

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -65,6 +65,8 @@
 #include "ui/wm/core/compound_event_filter.h"
 #include "ui/wm/core/window_util.h"
 
+#include "content/nw/src/browser/global_menu_bar_x11.h"
+
 DECLARE_WINDOW_PROPERTY_TYPE(views::DesktopWindowTreeHostX11*);
 
 namespace content {
@@ -512,6 +514,7 @@ void DesktopWindowTreeHostX11::Close() {
 }
 
 void DesktopWindowTreeHostX11::CloseNow() {
+  global_menu_bar_x11_.reset();
   if (xwindow_ == None)
     return;
 
@@ -2355,6 +2358,16 @@ ui::NativeTheme* DesktopWindowTreeHost::GetNativeTheme(aura::Window* window) {
   }
 
   return ui::NativeThemeAura::instance();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostX11, public:
+// NW fix
+
+void DesktopWindowTreeHostX11::SetGlobalMenu(ui::MenuModel* model) {
+  global_menu_bar_x11_.reset(model ?
+                               new nw::GlobalMenuBarX11(this, model) :
+                               nullptr);
 }
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
@@ -34,6 +34,11 @@ class ImageSkiaRep;
 namespace ui {
 class EventHandler;
 class XScopedEventSelector;
+class MenuModel;
+}
+
+namespace nw {
+class GlobalMenuBarX11;
 }
 
 namespace views {
@@ -90,6 +95,11 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Returns XID of dialog currently displayed. When it returns 0,
   // there is no dialog on the host window.
   XID GetModalDialog();
+
+  void SetGlobalMenu(ui::MenuModel *model);
+
+  // NW fix: expose GetAccleratedWidget
+  gfx::AcceleratedWidget GetAcceleratedWidget() override;
 
  protected:
   // Overridden from DesktopWindowTreeHost:
@@ -158,7 +168,6 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Overridden from aura::WindowTreeHost:
   gfx::Transform GetRootTransform() const override;
   ui::EventSource* GetEventSource() override;
-  gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void ShowImpl() override;
   void HideImpl() override;
   gfx::Rect GetBounds() const override;
@@ -426,6 +435,8 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   std::unique_ptr<aura::ScopedWindowTargeter> targeter_for_modal_;
 
   XID modal_dialog_xid_;
+
+  std::unique_ptr<nw::GlobalMenuBarX11> global_menu_bar_x11_;
 
   base::WeakPtrFactory<DesktopWindowTreeHostX11> close_widget_factory_;
   base::WeakPtrFactory<DesktopWindowTreeHostX11> weak_factory_;


### PR DESCRIPTION
Exposed APIs for global menubar on Ubuntu. This patch also removed
global menubar for DevTools window.

fixed partially on nwjs/nw.js#2718