### PR TITLE
enable flags for ac3 and hevc codecs

### DIFF
--- a/media/media_options.gni
+++ b/media/media_options.gni
@@ -36,14 +36,16 @@ declare_args() {
   # Enables AC3/EAC3 audio demuxing. This is enabled only on Chromecast, since
   # it only provides demuxing, and is only useful for AC3/EAC3 audio
   # pass-through to HDMI sink on Chromecast.
-  enable_ac3_eac3_audio_demuxing = proprietary_codecs && is_chromecast
+  # enable_ac3_eac3_audio_demuxing = proprietary_codecs && is_chromecast
+  enable_ac3_eac3_audio_demuxing = true
 
   enable_mse_mpeg2ts_stream_parser =
       (proprietary_codecs && is_chromecast) || use_libfuzzer || use_afl
 
   # Enable HEVC/H265 demuxing. Actual decoding must be provided by the
   # platform. Enable by default for Chromecast.
-  enable_hevc_demuxing = proprietary_codecs && is_chromecast
+  # enable_hevc_demuxing = proprietary_codecs && is_chromecast
+  enable_hevc_demuxing = true
 }
 
 # Use a second declare_args() to pick up possible overrides of |use_cras|.


### PR DESCRIPTION
Flags enable_ac3_eac3_audio_demuxing and enable_hevc_demuxing needed
to be enabled on Chromium side in order to be working with 3rd-party
built ffmpeg libraries for AC3 and HEVC codecs.

fixed nwjs/nw.js#5653