### PR TITLE
Improve working with history

### DIFF
--- a/chrome/browser/extensions/api/history/history_api.cc
+++ b/chrome/browser/extensions/api/history/history_api.cc
@@ -351,9 +351,16 @@ bool HistoryAddUrlFunction::RunAsync() {
   if (!ValidateUrl(params->details.url, &url))
     return false;
 
+  base::string16 title;
+  if (params->details.title.get())
+    title = base::UTF8ToUTF16(*params->details.title);
+
   history::HistoryService* hs = HistoryServiceFactory::GetForProfile(
       GetProfile(), ServiceAccessType::EXPLICIT_ACCESS);
   hs->AddPage(url, base::Time::Now(), history::SOURCE_EXTENSION);
+
+  if (!title.empty())
+    hs->SetPageTitle(url, title);
 
   SendResponse(true);
   return true;

--- a/chrome/common/extensions/api/history.json
+++ b/chrome/common/extensions/api/history.json
@@ -97,7 +97,8 @@
             "name": "details",
             "type": "object",
             "properties": {
-              "url": {"type": "string", "description": "The URL to add."}
+              "url": {"type": "string", "description": "The URL to add."},
+              "title": {"type": "string", "optional": true, "description": "The title of URL to add."}
             }
           },
           {

--- a/extensions/browser/guest_view/web_view/web_view_guest.cc
+++ b/extensions/browser/guest_view/web_view/web_view_guest.cc
@@ -26,6 +26,7 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
+#include "content/public/browser/favicon_status.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/notification_details.h"
@@ -842,6 +843,16 @@ void WebViewGuest::DidCommitProvisionalLoadForFrame(
                    web_contents()->GetController().GetCurrentEntryIndex());
   args->SetInteger(webview::kInternalEntryCount,
                    web_contents()->GetController().GetEntryCount());
+
+  base::ListValue *history = new base::ListValue();
+  for (int i = 0; i < web_contents()->GetController().GetEntryCount(); i++) {
+    base::DictionaryValue* dict = new base::DictionaryValue;
+    dict->SetString("url", web_contents()->GetController().GetEntryAtIndex(i)->GetURL().spec());
+    dict->SetString("title", web_contents()->GetController().GetEntryAtIndex(i)->GetTitle());
+    dict->SetString("favicon", web_contents()->GetController().GetEntryAtIndex(i)->GetFavicon().url.spec());
+    history->Append(dict);
+  }
+  args->Set("pagesHistory", history);
   args->SetInteger(webview::kInternalProcessId,
                    web_contents()->GetRenderProcessHost()->GetID());
   DispatchEventToView(base::MakeUnique<GuestViewEvent>(

--- a/extensions/renderer/resources/guest_view/web_view/web_view.js
+++ b/extensions/renderer/resources/guest_view/web_view/web_view.js
@@ -148,11 +148,12 @@ WebViewImpl.prototype.onFrameNameChanged = function(name) {
 // Updates state upon loadcommit.
 WebViewImpl.prototype.onLoadCommit = function(
     baseUrlForDataUrl, currentEntryIndex, entryCount,
-    processId, url, isTopLevel) {
+    processId, url, isTopLevel, pagesHistory) {
   this.baseUrlForDataUrl = baseUrlForDataUrl;
   this.currentEntryIndex = currentEntryIndex;
   this.entryCount = entryCount;
   this.processId = processId;
+  this.pagesHistory = pagesHistory;
   if (isTopLevel) {
     // Touching the src attribute triggers a navigation. To avoid
     // triggering a page reload on every guest-initiated navigation,

--- a/extensions/renderer/resources/guest_view/web_view/web_view_api_methods.js
+++ b/extensions/renderer/resources/guest_view/web_view/web_view_api_methods.js
@@ -52,6 +52,12 @@ var WEB_VIEW_API_METHODS = [
   // Navigates to the subsequent history entry.
   'forward',
 
+  // Get current history index
+  'getCurrentHistoryIndex',
+
+  // Get array with history of URLs titles and favicons
+  'getPagesHistory',
+
   // Returns Chrome's internal process ID for the guest web page's current
   // process.
   'getProcessId',
@@ -82,6 +88,7 @@ var WEB_VIEW_API_METHODS = [
   'loadDataWithBaseUrl',
 
   'showDevTools',
+
   // Prints the contents of the webview.
   'print',
 
@@ -149,6 +156,14 @@ WebViewImpl.prototype.getGuestId = function() {
 
 WebViewImpl.prototype.getUserAgent = function() {
   return this.userAgentOverride || navigator.userAgent;
+};
+
+WebViewImpl.prototype.getCurrentHistoryIndex = function () {
+    return this.currentEntryIndex;
+};
+
+WebViewImpl.prototype.getPagesHistory = function() {
+    return this.pagesHistory;
 };
 
 WebViewImpl.prototype.insertCSS = function(var_args) {

--- a/extensions/renderer/resources/guest_view/web_view/web_view_events.js
+++ b/extensions/renderer/resources/guest_view/web_view/web_view_events.js
@@ -249,7 +249,8 @@ WebViewEvents.prototype.handleLoadCommitEvent = function(event, eventName) {
                          event.entryCount,
                          event.processId,
                          event.url,
-                         event.isTopLevel);
+                         event.isTopLevel,
+                         event.pagesHistory);
   var webViewEvent = this.makeDomEvent(event, eventName);
   this.view.dispatchEvent(webViewEvent);
 };


### PR DESCRIPTION
On webview: getPagesHistory function, returning array of URLs, titles and favicons of pages in history, getCurrentHistoryIndex function, returning current history index

chrome.history.addUrl - optional title attribute added

See:
https://github.com/nwjs/nw.js/issues/1507

Our project:
https://groups.google.com/forum/#!topic/nwjs-general/TmZUq-JHIuQ