### PR TITLE
Enhance chrome.app.window API with window background color

### DIFF
--- a/chrome/browser/resources/nwjs/default.js
+++ b/chrome/browser/resources/nwjs/default.js
@@ -34,6 +34,8 @@ if (manifest.window) {
     options.visibleOnAllWorkspaces = true;
   if (manifest.window.transparent)
     options.alphaEnabled = true;
+  if (manifest.window.background_color)
+    options.backgroundColor = manifest.window.background_color;
   if (manifest.window.kiosk === true)
     options.kiosk = true;
   if (manifest.window.position)

--- a/chrome/browser/ui/cocoa/apps/native_app_window_cocoa.mm
+++ b/chrome/browser/ui/cocoa/apps/native_app_window_cocoa.mm
@@ -690,11 +690,14 @@ bool NativeAppWindowCocoa::IsAlwaysOnTop() const {
 void NativeAppWindowCocoa::RenderViewCreated(content::RenderViewHost* rvh) {
   if (IsActive())
     WebContents()->RestoreFocus();
+
+  content::RenderWidgetHostView* view = rvh->GetWidget()->GetView();
+  DCHECK(view);
   if (content::g_support_transparency &&
       app_window_->requested_alpha_enabled() && CanHaveAlphaEnabled()) {
-    content::RenderWidgetHostView* view = rvh->GetWidget()->GetView();
-    DCHECK(view);
     view->SetBackgroundColor(SK_ColorTRANSPARENT);
+  } else if (app_window_->backgroundColor() != SK_ColorWHITE) {
+    view->SetBackgroundColor(app_window_->backgroundColor());
   }
 }
 

--- a/content/browser/renderer_host/render_widget_host_impl.cc
+++ b/content/browser/renderer_host/render_widget_host_impl.cc
@@ -2256,6 +2256,10 @@ void RenderWidgetHostImpl::SetBackgroundOpaque(bool opaque) {
   Send(new ViewMsg_SetBackgroundOpaque(GetRoutingID(), opaque));
 }
 
+void RenderWidgetHostImpl::SetBaseBackgroundColor(SkColor color) {
+  Send(new ViewMsg_SetBaseBackgroundColor(GetRoutingID(), color));
+}
+
 void RenderWidgetHostImpl::SetEditCommandsForNextKeyEvent(
     const std::vector<EditCommand>& commands) {
   Send(new InputMsg_SetEditCommandsForNextKeyEvent(GetRoutingID(), commands));

--- a/content/browser/renderer_host/render_widget_host_impl.h
+++ b/content/browser/renderer_host/render_widget_host_impl.h
@@ -437,6 +437,9 @@ class CONTENT_EXPORT RenderWidgetHostImpl : public RenderWidgetHost,
   // Set the RenderView background transparency.
   void SetBackgroundOpaque(bool opaque);
 
+  // Set background color.
+  void SetBaseBackgroundColor(SkColor);
+
   // Notifies the renderer that the next key event is bound to one or more
   // pre-defined edit commands
   void SetEditCommandsForNextKeyEvent(

--- a/content/browser/renderer_host/render_widget_host_view_aura.cc
+++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
@@ -753,6 +753,8 @@ void RenderWidgetHostViewAura::SetBackgroundColor(SkColor color) {
   host_->SetBackgroundOpaque(opaque);
   window_->layer()->SetFillsBoundsOpaquely(opaque);
   window_->layer()->SetColor(color);
+  if (opaque && color != SK_ColorWHITE)
+    host_->SetBaseBackgroundColor(color);
 }
 
 bool RenderWidgetHostViewAura::IsMouseLocked() {

--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
+++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
@@ -1650,6 +1650,9 @@ void RenderWidgetHostViewMac::SetBackgroundColor(SkColor color) {
   if (render_widget_host_)
     render_widget_host_->SetBackgroundOpaque(opaque);
 
+  if (opaque && color != SK_ColorWHITE)
+    render_widget_host_->SetBaseBackgroundColor(color);
+
   [cocoa_view_ setOpaque:opaque];
 
   browser_compositor_->SetHasTransparentBackground(!opaque);

--- a/content/common/view_messages.h
+++ b/content/common/view_messages.h
@@ -520,6 +520,9 @@ IPC_MESSAGE_ROUTED1(ViewMsg_SetTextDirection,
 // Make the RenderView background transparent or opaque.
 IPC_MESSAGE_ROUTED1(ViewMsg_SetBackgroundOpaque, bool /* opaque */)
 
+// Set the RenderView background color.
+IPC_MESSAGE_ROUTED1(ViewMsg_SetBaseBackgroundColor, SkColor /* color */)
+
 // Used to tell the renderer not to add scrollbars with height and
 // width below a threshold.
 IPC_MESSAGE_ROUTED1(ViewMsg_DisableScrollbarsForSmallWindows,

--- a/content/renderer/render_view_impl.cc
+++ b/content/renderer/render_view_impl.cc
@@ -1222,6 +1222,7 @@ bool RenderViewImpl::OnMessageReceived(const IPC::Message& message) {
     IPC_MESSAGE_HANDLER(ViewMsg_ClosePage, OnClosePage)
     IPC_MESSAGE_HANDLER(ViewMsg_MoveOrResizeStarted, OnMoveOrResizeStarted)
     IPC_MESSAGE_HANDLER(ViewMsg_SetBackgroundOpaque, OnSetBackgroundOpaque)
+    IPC_MESSAGE_HANDLER(ViewMsg_SetBaseBackgroundColor, OnSetBaseBackgroundColor)
     IPC_MESSAGE_HANDLER(ViewMsg_EnablePreferredSizeChangedMode,
                         OnEnablePreferredSizeChangedMode)
     IPC_MESSAGE_HANDLER(ViewMsg_EnableAutoResize, OnEnableAutoResize)
@@ -2280,6 +2281,11 @@ void RenderViewImpl::OnSetBackgroundOpaque(bool opaque) {
     frame_widget_->setIsTransparent(!opaque);
   if (compositor_)
     compositor_->setHasTransparentBackground(!opaque);
+}
+
+void RenderViewImpl::OnSetBaseBackgroundColor(SkColor color) {
+  if (frame_widget_)
+    frame_widget_->setBaseBackgroundColor(color);
 }
 
 void RenderViewImpl::OnSetActive(bool active) {

--- a/content/renderer/render_view_impl.h
+++ b/content/renderer/render_view_impl.h
@@ -550,6 +550,7 @@ class CONTENT_EXPORT RenderViewImpl
   void OnReleaseDisambiguationPopupBitmap(const cc::SharedBitmapId& id);
   void OnSetActive(bool active);
   void OnSetBackgroundOpaque(bool opaque);
+  void OnSetBaseBackgroundColor(SkColor color);
   void OnExitFullscreen();
   void OnSetHistoryOffsetAndLength(int history_offset, int history_length);
   void OnSetInitialFocus(bool reverse);

--- a/extensions/browser/api/app_window/app_window_api.cc
+++ b/extensions/browser/api/app_window/app_window_api.cc
@@ -324,6 +324,15 @@ bool AppWindowCreateFunction::RunAsync() {
 #endif
     }
 
+    if (options->background_color.get()) {
+      if (!image_util::ParseHexColorString(
+              *options->background_color,
+              &create_params.background_color)) {
+        error_ = app_window_constants::kInvalidColorSpecification;
+        return false;
+      }
+    }
+
     if (options->hidden.get())
       create_params.hidden = *options->hidden;
 

--- a/extensions/browser/app_window/app_window.cc
+++ b/extensions/browser/app_window/app_window.cc
@@ -183,6 +183,7 @@ AppWindow::CreateParams::CreateParams()
       active_frame_color(SK_ColorBLACK),
       inactive_frame_color(SK_ColorBLACK),
       alpha_enabled(false),
+      background_color(SK_ColorWHITE),
       is_ime_window(false),
       creator_process_id(0),
       state(ui::SHOW_STATE_DEFAULT),
@@ -271,6 +272,7 @@ AppWindow::AppWindow(BrowserContext* context,
       is_hidden_(false),
       cached_always_on_top_(false),
       requested_alpha_enabled_(false),
+      background_color_(SK_ColorWHITE),
       is_ime_window_(false),
       last_to_different_document_(false),
       show_in_shelf_(false),
@@ -360,6 +362,7 @@ void AppWindow::Init(const GURL& url,
   }
 
   requested_alpha_enabled_ = new_params.alpha_enabled;
+  background_color_ = new_params.background_color;
   is_ime_window_ = params.is_ime_window;
   show_in_shelf_ = params.show_in_shelf;
   window_icon_url_ = params.window_icon_url;

--- a/extensions/browser/app_window/app_window.h
+++ b/extensions/browser/app_window/app_window.h
@@ -165,6 +165,7 @@ class AppWindow : public content::WebContentsDelegate,
     SkColor active_frame_color;
     SkColor inactive_frame_color;
     bool alpha_enabled;
+    SkColor background_color;
     bool is_ime_window;
 
     // The initial content/inner bounds specification (excluding any window
@@ -394,6 +395,9 @@ class AppWindow : public content::WebContentsDelegate,
   // Whether the app window wants to be alpha enabled.
   bool requested_alpha_enabled() const { return requested_alpha_enabled_; }
 
+  // Set background color
+  SkColor backgroundColor() const { return background_color_; }
+
   // Whether the app window is created by IME extensions.
   // TODO(bshe): rename to hide_app_window_in_launcher if it is not used
   // anywhere other than app_window_launcher_controller after M45. Otherwise,
@@ -598,6 +602,9 @@ class AppWindow : public content::WebContentsDelegate,
 
   // Whether |alpha_enabled| was set in the CreateParams.
   bool requested_alpha_enabled_;
+
+  // Set background color
+  SkColor background_color_;
 
   // Whether |is_ime_window| was set in the CreateParams.
   bool is_ime_window_;

--- a/extensions/common/api/app_window.idl
+++ b/extensions/common/api/app_window.idl
@@ -257,6 +257,9 @@ namespace app.window {
     // permission.
     [nodoc] boolean? alphaEnabled;
 
+    // Set window background color.
+    [nodoc] DOMString? backgroundColor;
+
     // The initial state of the window, allowing it to be created already
     // fullscreen, maximized, or minimized. Defaults to 'normal'.
     State? state;

--- a/extensions/components/native_app_window/native_app_window_views.cc
+++ b/extensions/components/native_app_window/native_app_window_views.cc
@@ -323,11 +323,14 @@ void NativeAppWindowViews::OnWidgetActivationChanged(views::Widget* widget,
 
 void NativeAppWindowViews::RenderViewCreated(
     content::RenderViewHost* render_view_host) {
+  content::RenderWidgetHostView* view =
+      render_view_host->GetWidget()->GetView();
+  DCHECK(view);
+
   if (app_window_->requested_alpha_enabled() && CanHaveAlphaEnabled()) {
-    content::RenderWidgetHostView* view =
-        render_view_host->GetWidget()->GetView();
-    DCHECK(view);
     view->SetBackgroundColor(SK_ColorTRANSPARENT);
+  } else if (app_window_->backgroundColor() != SK_ColorWHITE) {
+    view->SetBackgroundColor(app_window_->backgroundColor());
   }
 }
 


### PR DESCRIPTION
The default background color of window is white, a flash of white
will be shown if the loaded page uses a dark background. So add a new
property named background_color to CreateWindowOptions that can be configured
the same as page dark background instead of white default color.

BUG=https://github.com/nwjs/nw.js/issues/5502