### PR TITLE
Fix #5738: nwjs doesn't need permission check

### DIFF
--- a/extensions/browser/api/app_current_window_internal/app_current_window_internal_api.cc
+++ b/extensions/browser/api/app_current_window_internal/app_current_window_internal_api.cc
@@ -366,8 +366,10 @@ AppCurrentWindowInternalSetShapeFunction::Run() {
 
 ExtensionFunction::ResponseAction
 AppCurrentWindowInternalSetAlwaysOnTopFunction::Run() {
+
   // TODO(devlin): Can't this be done with the feature files?
-  if (!extension()->permissions_data()->HasAPIPermission(
+  if (extension() != nullptr && // NWJS#5738
+      !extension()->permissions_data()->HasAPIPermission(
           extensions::APIPermission::kAlwaysOnTopWindows)) {
     return RespondNow(Error(kAlwaysOnTopPermission));
   }


### PR DESCRIPTION
Call setAlwaysOnTop in the new created window will cause crash, that's because in this case, there is nullptr in ExtensionFunction::extension().