### PR TITLE
Fix Linux debug build.

### DIFF
--- a/headless/BUILD.gn
+++ b/headless/BUILD.gn
@@ -754,12 +754,6 @@ static_library("headless_shell_lib") {
     "lib/browser/headless_content_browser_client.h",
     "public/headless_shell.h",
   ]
-  if (is_debug && is_linux) {
-    sources += [
-      "app/headless_shell_switches.cc",
-      "app/headless_shell_switches.h",
-    ]
-  }
 
   deps = [
     ":headless_renderer",


### PR DESCRIPTION
GN reports the following error when trying to build NW.js on Linux with is_debug=true:
```
ERROR at //headless/BUILD.gn:747:1: Duplicate object file
static_library("headless_shell_lib") {
^-------------------------------------
The target //headless:headless_shell_lib
generates two object files with the same name:
  obj/headless/headless_shell_lib/headless_shell_switches.o

It could be you accidentally have a file listed twice in the
sources. Or, depending on how your toolchain maps sources to
object files, two source files with the same name in different
directories could map to the same object file.

In the latter case, either rename one of the files or move one of
the sources to a separate source_set to avoid them both being in
the same target.
```
The duplication error is caused by
https://github.com/nwjs/chromium.src/blob/dcf96012c9c2093e38d49af4dd17c5e680f0ed42/headless/BUILD.gn#L757-L762,
which seems to be unnecessary here.