### PR TITLE
[Transparency][Win] Fix #6204,wrong window size during maximize when transparency is enabled

### DIFF
--- a/content/browser/compositor/software_output_device_win.cc
+++ b/content/browser/compositor/software_output_device_win.cc
@@ -12,12 +12,8 @@
 #include "skia/ext/skia_utils_win.h"
 #include "ui/base/win/internal_constants.h"
 #include "ui/compositor/compositor.h"
-#include "ui/display/display.h"
 #include "ui/gfx/gdi_util.h"
 #include "ui/gfx/skia_util.h"
-#include "ui/gfx/win/hwnd_util.h"
-#include "ui/views/win/hwnd_message_handler.h"
-#include "ui/views/win/hwnd_message_handler_delegate.h"
 
 namespace content {
 
@@ -171,11 +167,6 @@ void SoftwareOutputDeviceWin::EndPaint() {
     return;
 
   HDC dib_dc = skia::GetNativeDrawingContext(contents_.get());
-  if (g_force_cpu_draw) {
-    is_hwnd_composited_ = !!::GetProp(hwnd_, ui::kWindowTranslucent);
-    views::HWNDMessageHandler* window = reinterpret_cast<views::HWNDMessageHandler*>(gfx::GetWindowUserData(hwnd_));
-    is_hwnd_composited_ &= !(window->delegate_->HasFrame());
-  }
 
   if (is_hwnd_composited_) {
     RECT wr;

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
@@ -905,7 +905,6 @@ void DesktopWindowTreeHostWin::HandleInputLanguageChange(
 
 void DesktopWindowTreeHostWin::HandlePaintAccelerated(
     const gfx::Rect& invalid_rect) {
-  if (content::g_force_cpu_draw) return;
   if (compositor())
     compositor()->ScheduleRedrawRect(invalid_rect);
 }


### PR DESCRIPTION
Fix https://github.com/nwjs/nw.js/issues/6204,wrong window size during maximize when transparency is enabled