### PR TITLE
Windows desktop capture extract exe name and window position

### DIFF
--- a/chrome/browser/extensions/api/desktop_capture/desktop_capture_api.cc
+++ b/chrome/browser/extensions/api/desktop_capture/desktop_capture_api.cc
@@ -14,6 +14,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/origin_util.h"
 #include "net/base/url_util.h"
+#include "extensions/common/manifest_constants.h"
 
 namespace extensions {
 
@@ -93,7 +94,14 @@ bool DesktopCaptureChooseDesktopMediaFunction::RunAsync() {
     // NWJS app allows running on origins other than `chrome-extension://*/*`.
     // The origin should then be from the senders URL, in order not to fail
     // the origin checking in `DesktopStreamsRegistry::RequestMediaForStreamId`.
-    origin = extension()->is_nwjs_app() ? web_contents->GetURL().GetOrigin() : extension()->url();
+    if (extension()->is_nwjs_app()) {
+      std::string desktopStreamOriginOverride;
+      extension()->manifest()->GetString(manifest_keys::kNWJSDesktopStreamOriginOverride, &desktopStreamOriginOverride);
+      origin = desktopStreamOriginOverride.empty() ? web_contents->GetURL().GetOrigin() : GURL(desktopStreamOriginOverride);
+    }
+    else {
+      origin = extension()->url();
+    }
     DCHECK(web_contents);
   }
 

--- a/chrome/browser/media/webrtc/desktop_media_list.h
+++ b/chrome/browser/media/webrtc/desktop_media_list.h
@@ -28,6 +28,12 @@ class DesktopMediaList {
 
     // The thumbnail for the source.
     gfx::ImageSkia thumbnail;
+
+    // Name of the executable.
+    base::string16 exeName;
+
+    Source();
+    Source(const Source& other);
   };
 
   virtual ~DesktopMediaList() {}

--- a/chrome/browser/media/webrtc/desktop_media_list_base.cc
+++ b/chrome/browser/media/webrtc/desktop_media_list_base.cc
@@ -13,6 +13,11 @@
 using content::BrowserThread;
 using content::DesktopMediaID;
 
+DesktopMediaList::Source::Source() {
+}
+
+DesktopMediaList::Source::Source(const Source& other) = default;
+
 DesktopMediaListBase::DesktopMediaListBase(base::TimeDelta update_period)
     : update_period_(update_period), weak_factory_(this) {}
 
@@ -55,8 +60,9 @@ DesktopMediaID::Type DesktopMediaListBase::GetMediaListType() const {
 
 DesktopMediaListBase::SourceDescription::SourceDescription(
     DesktopMediaID id,
-    const base::string16& name)
-    : id(id), name(name) {}
+    const base::string16& name,
+    const base::string16& exeName)
+    : id(id), name(name), exeName(exeName) {}
 
 void DesktopMediaListBase::UpdateSourcesList(
     const std::vector<SourceDescription>& new_sources) {
@@ -85,6 +91,7 @@ void DesktopMediaListBase::UpdateSourcesList(
         sources_.insert(sources_.begin() + i, Source());
         sources_[i].id = new_sources[i].id;
         sources_[i].name = new_sources[i].name;
+        sources_[i].exeName = new_sources[i].exeName;
         observer_->OnSourceAdded(this, i);
       }
     }

--- a/chrome/browser/media/webrtc/desktop_media_list_base.h
+++ b/chrome/browser/media/webrtc/desktop_media_list_base.h
@@ -36,10 +36,11 @@ class DesktopMediaListBase : public DesktopMediaList {
 
  protected:
   struct SourceDescription {
-    SourceDescription(content::DesktopMediaID id, const base::string16& name);
+    SourceDescription(content::DesktopMediaID id, const base::string16& name, const base::string16& exeName);
 
     content::DesktopMediaID id;
     base::string16 name;
+    base::string16 exeName;
   };
 
   virtual void Refresh() = 0;

--- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
+++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
@@ -127,6 +127,7 @@ void NativeDesktopMediaList::Worker::Refresh(
 
   bool mutiple_sources = sources.size() > 1;
   base::string16 title;
+  base::string16 exeName;
   for (size_t i = 0; i < sources.size(); ++i) {
     switch (type_) {
       case DesktopMediaID::TYPE_SCREEN:
@@ -138,6 +139,7 @@ void NativeDesktopMediaList::Worker::Refresh(
                           static_cast<int>(i + 1))
                     : l10n_util::GetStringUTF16(
                           IDS_DESKTOP_MEDIA_PICKER_SINGLE_SCREEN_NAME);
+        exeName = base::UTF8ToUTF16(sources[i].exeName);
         break;
 
       case DesktopMediaID::TYPE_WINDOW:
@@ -145,13 +147,14 @@ void NativeDesktopMediaList::Worker::Refresh(
         if (sources[i].id == view_dialog_id)
           continue;
         title = base::UTF8ToUTF16(sources[i].title);
+        exeName = base::UTF8ToUTF16(sources[i].exeName);
         break;
 
       default:
         NOTREACHED();
     }
     result.push_back(
-        SourceDescription(DesktopMediaID(type_, sources[i].id), title));
+        SourceDescription(DesktopMediaID(type_, sources[i].id), title, exeName));
   }
 
   BrowserThread::PostTask(

--- a/chrome/browser/media/webrtc/tab_desktop_media_list.cc
+++ b/chrome/browser/media/webrtc/tab_desktop_media_list.cc
@@ -108,7 +108,7 @@ void TabDesktopMediaList::Refresh() {
       // Get tab's last active time stamp.
       const base::TimeTicks t = contents->GetLastActiveTime();
       tab_map.insert(
-          std::make_pair(t, SourceDescription(media_id, contents->GetTitle())));
+          std::make_pair(t, SourceDescription(media_id, contents->GetTitle(), base::string16())));
 
       // Get favicon for tab.
       favicon::FaviconDriver* favicon_driver =

--- a/extensions/common/manifest_constants.cc
+++ b/extensions/common/manifest_constants.cc
@@ -16,6 +16,7 @@ const char kNWJSMain[] = "main";
 const char kNWJSMixedContext[] = "mixed_context";
 const char kNWJSEnableNode[] = "nodejs";
 const char kNWJSDomain[] = "domain";
+const char kNWJSDesktopStreamOriginOverride[] = "desktop_stream_origin_override";
 
 const char kAboutPage[] = "about_page";
 const char kAction[] = "action";

--- a/extensions/common/manifest_constants.h
+++ b/extensions/common/manifest_constants.h
@@ -19,6 +19,7 @@ extern const char kNWJSMain[];
 extern const char kNWJSMixedContext[];
 extern const char kNWJSEnableNode[];
 extern const char kNWJSDomain[];
+extern const char kNWJSDesktopStreamOriginOverride[];
 
 extern const char kAboutPage[];
 extern const char kAction[];

--- a/mojo/public/tools/bindings/generators/mojom_java_generator.py
+++ b/mojo/public/tools/bindings/generators/mojom_java_generator.py
@@ -411,7 +411,7 @@ def TempDir():
   try:
     yield dirname
   finally:
-    shutil.rmtree(dirname)
+    shutil.rmtree(dirname, ignore_errors=True)
 
 class Generator(generator.Generator):
   def _GetJinjaExports(self):


### PR DESCRIPTION
Changes to Desktop Capture Monitor for Windows to allow you to extract the exeName of applications as well as the window position of shared applications