### PR TITLE
[Transparency][MacOS] fix click-through transparency doesn't work on nw36

### DIFF
--- a/ui/views_bridge_mac/bridged_native_widget_impl.mm
+++ b/ui/views_bridge_mac/bridged_native_widget_impl.mm
@@ -538,8 +538,8 @@ void BridgedNativeWidgetImpl::CreateContentView(uint64_t ns_view_id,
   [bridged_view_ addSubview:compositor_view];
 
   if (content::g_force_cpu_draw) {
-    [bridged_view_ setLayer:nil];
-    [bridged_view_ setWantsLayer:NO];
+    [compositor_view setLayer:nil];
+    [compositor_view setWantsLayer:NO];
     //DisplayCALayerTree flipped_layer_
     CALayer* flipped_layer = background_layer.sublayers[0];
     [bridged_view_ setForceCPUDrawLayer:flipped_layer];


### PR DESCRIPTION
fix https://github.com/nwjs/nw.js/issues/6708 click-through transparency doesn't work on nw36