### PR TITLE
Fix duplicate symbol error for `HeadlessContentMainDelegate`

### DIFF
--- a/headless/BUILD.gn
+++ b/headless/BUILD.gn
@@ -304,8 +304,6 @@ source_set("headless_shared_sources") {
   sources = [
     "app/headless_shell_switches.cc",
     "app/headless_shell_switches.h",
-    "lib/headless_content_main_delegate.cc",
-    "lib/headless_content_main_delegate.h",
     "lib/headless_content_client.cc",
     "lib/headless_content_client.h",
     "public/headless_browser.cc",
@@ -629,6 +627,8 @@ if (!is_component_build) {
     sources = [
       #"lib/browser/headless_web_contents_impl.cc",
       #"lib/browser/headless_web_contents_impl.h",
+      "lib/headless_content_main_delegate.cc",
+      "lib/headless_content_main_delegate.h",
       "lib/renderer/headless_content_renderer_client.cc",
       "lib/renderer/headless_content_renderer_client.h",
       "lib/utility/headless_content_utility_client.cc",


### PR DESCRIPTION
This PR syncs
NW's Chromium's headless/BUILD.gn with upstream. This prevents a duplicate symbol error while building debug version on Linux. I think this change is important because people new to C++ or even programming in general could be discouraged from building/contributing to the project.

Here's the error log which led me to the fix:
```shell
cd $HOME/nwjs/src && gn gen out/nw '--args=is_debug=true target_cpu="x64" is_component_build=true'
cd $HOME/nwjs/src && ninja -C out/nw nwjs
ninja: Entering directory `out/nw'
[1/6] SOLINK ./lib/libheadless_non_renderer.so
FAILED: lib/libheadless_non_renderer.so lib/libheadless_non_renderer.so.TOC
python3 "../../build/toolchain/gcc_solink_wrapper.py" --readelf="../../third_party/llvm-build/Release+Asserts/bin/llvm-readelf" --nm="../../third_party/llvm-build/Release+Asserts/bin/llvm-nm"  --sofile="./lib/libheadless_non_renderer.so" --tocfile="./lib/libheadless_non_renderer.so.TOC" --output="./lib/libheadless_non_renderer.so" -- ../../third_party/llvm-build/Release+Asserts/bin/clang++ -shared -Wl,-soname="libheadless_non_renderer.so" -Werror -fuse-ld=lld -Wl,--fatal-warnings -Wl,--build-id -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,--color-diagnostics -Wl,--no-call-graph-profile-sort -m64 -no-canonical-prefixes -Wl,--gdb-index -rdynamic -Wl,-z,defs -Wl,--as-needed -nostdlib++ --sysroot=../../build/linux/debian_bullseye_amd64-sysroot -o "./lib/libheadless_non_renderer.so" @"./lib/libheadless_non_renderer.so.rsp"
ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::HeadlessContentMainDelegate(std::__1::unique_ptr<headless::HeadlessBrowserImpl, std::__1::default_delete<headless::HeadlessBrowserImpl>>)
>>> defined at headless_content_main_delegate.cc:160 (../../headless/lib/headless_content_main_delegate.cc:160)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::HeadlessContentMainDelegate(std::__1::unique_ptr<headless::HeadlessBrowserImpl, std::__1::default_delete<headless::HeadlessBrowserImpl>>))
>>> defined at headless_content_main_delegate.cc:160 (../../headless/lib/headless_content_main_delegate.cc:160)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x0)

ld.lld: error: duplicate symbol: vtable for headless::HeadlessContentMainDelegate
>>> defined at headless_content_main_delegate.cc
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(vtable for headless::HeadlessContentMainDelegate)
>>> defined at headless_content_main_delegate.cc
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.data.rel.ro+0x0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::Init()
>>> defined at headless_content_main_delegate.cc:170 (../../headless/lib/headless_content_main_delegate.cc:170)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::Init())
>>> defined at headless_content_main_delegate.cc:170 (../../headless/lib/headless_content_main_delegate.cc:170)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0xA0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::HeadlessContentMainDelegate(headless::HeadlessBrowser::Options)
>>> defined at headless_content_main_delegate.cc:166 (../../headless/lib/headless_content_main_delegate.cc:166)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::HeadlessContentMainDelegate(headless::HeadlessBrowser::Options))
>>> defined at headless_content_main_delegate.cc:166 (../../headless/lib/headless_content_main_delegate.cc:166)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x130)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate()
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate())
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1D0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate()
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate())
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x2D0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate()
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::~HeadlessContentMainDelegate())
>>> defined at headless_content_main_delegate.cc:175 (../../headless/lib/headless_content_main_delegate.cc:175)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1D0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::BasicStartupComplete()
>>> defined at headless_content_main_delegate.cc:180 (../../headless/lib/headless_content_main_delegate.cc:180)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::BasicStartupComplete())
>>> defined at headless_content_main_delegate.cc:180 (../../headless/lib/headless_content_main_delegate.cc:180)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x300)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::options()
>>> defined at headless_content_main_delegate.cc:442 (../../headless/lib/headless_content_main_delegate.cc:442)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::options())
>>> defined at headless_content_main_delegate.cc:442 (../../headless/lib/headless_content_main_delegate.cc:442)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x610)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::InitLogging(base::CommandLine const&)
>>> defined at headless_content_main_delegate.cc:229 (../../headless/lib/headless_content_main_delegate.cc:229)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::InitLogging(base::CommandLine const&))
>>> defined at headless_content_main_delegate.cc:229 (../../headless/lib/headless_content_main_delegate.cc:229)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x680)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::InitCrashReporter(base::CommandLine const&)
>>> defined at headless_content_main_delegate.cc:318 (../../headless/lib/headless_content_main_delegate.cc:318)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::InitCrashReporter(base::CommandLine const&))
>>> defined at headless_content_main_delegate.cc:318 (../../headless/lib/headless_content_main_delegate.cc:318)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0xE20)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::PreSandboxStartup()
>>> defined at headless_content_main_delegate.cc:352 (../../headless/lib/headless_content_main_delegate.cc:352)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::PreSandboxStartup())
>>> defined at headless_content_main_delegate.cc:352 (../../headless/lib/headless_content_main_delegate.cc:352)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0xF70)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::RunProcess(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, content::MainFunctionParams)
>>> defined at headless_content_main_delegate.cc:377 (../../headless/lib/headless_content_main_delegate.cc:377)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::RunProcess(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, content::MainFunctionParams))
>>> defined at headless_content_main_delegate.cc:377 (../../headless/lib/headless_content_main_delegate.cc:377)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1420)

ld.lld: error: duplicate symbol: headless::SIGTERMProfilingShutdown(int)
>>> defined at headless_content_main_delegate.cc:403 (../../headless/lib/headless_content_main_delegate.cc:403)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::SIGTERMProfilingShutdown(int))
>>> defined at headless_content_main_delegate.cc:403 (../../headless/lib/headless_content_main_delegate.cc:403)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x16B0)

ld.lld: error: duplicate symbol: headless::SetUpProfilingShutdownHandler()
>>> defined at headless_content_main_delegate.cc:412 (../../headless/lib/headless_content_main_delegate.cc:412)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::SetUpProfilingShutdownHandler())
>>> defined at headless_content_main_delegate.cc:412 (../../headless/lib/headless_content_main_delegate.cc:412)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x17A0)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::ZygoteForked()
>>> defined at headless_content_main_delegate.cc:420 (../../headless/lib/headless_content_main_delegate.cc:420)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::ZygoteForked())
>>> defined at headless_content_main_delegate.cc:420 (../../headless/lib/headless_content_main_delegate.cc:420)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1880)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::GetInstance()
>>> defined at headless_content_main_delegate.cc:438 (../../headless/lib/headless_content_main_delegate.cc:438)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::GetInstance())
>>> defined at headless_content_main_delegate.cc:438 (../../headless/lib/headless_content_main_delegate.cc:438)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1960)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::CreateContentClient()
>>> defined at headless_content_main_delegate.cc:448 (../../headless/lib/headless_content_main_delegate.cc:448)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::CreateContentClient())
>>> defined at headless_content_main_delegate.cc:448 (../../headless/lib/headless_content_main_delegate.cc:448)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1970)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::CreateContentBrowserClient()
>>> defined at headless_content_main_delegate.cc:453 (../../headless/lib/headless_content_main_delegate.cc:453)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::CreateContentBrowserClient())
>>> defined at headless_content_main_delegate.cc:453 (../../headless/lib/headless_content_main_delegate.cc:453)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x1990)

ld.lld: error: duplicate symbol: headless::HeadlessContentMainDelegate::CreateContentRendererClient()
>>> defined at headless_content_main_delegate.cc:460 (../../headless/lib/headless_content_main_delegate.cc:460)
>>>            obj/headless/headless_non_renderer/headless_content_main_delegate.o:(headless::HeadlessContentMainDelegate::CreateContentRendererClient())
>>> defined at headless_content_main_delegate.cc:460 (../../headless/lib/headless_content_main_delegate.cc:460)
>>>            obj/headless/headless_shared_sources/headless_content_main_delegate.o:(.text+0x19F0)

ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

cc @rogerwang 