### PR TITLE
Do not disable nw if node is disabled via manifest

### DIFF
--- a/extensions/renderer/native_extension_bindings_system.cc
+++ b/extensions/renderer/native_extension_bindings_system.cc
@@ -350,8 +350,7 @@ v8::Local<v8::Object> CreateFullBinding(
   // entered.
   for (auto iter = lower; iter != features.end() && iter->first < upper;
        ++iter) {
-    //if (iter->first.substr(0, 3) == "nw." && !nodejs_enabled)
-    //  continue;
+
     if (iter->second->IsInternal())
       continue;
 
@@ -583,7 +582,7 @@ void NativeExtensionBindingsSystem::UpdateBindingsForContext(
       context->context_type() == Feature::BLESSED_WEB_PAGE_CONTEXT ||
      command_line.HasSwitch("nwjs-guest-nw")))
     hidden_nw = false;
-  nw_obj = GetOrCreateChrome(v8_context, "nw", hidden_nw);
+  nw_obj = GetOrCreateChrome(v8_context, "nw", false);
 
   auto set_accessor_nw = [nw_obj, isolate,
                           v8_context, hidden_nw](base::StringPiece accessor_name) {


### PR DESCRIPTION
Fixes: https://github.com/nwjs/nw.js/issues/7994

https://github.com/nwjs/chromium.src/blob/nw75/extensions/renderer/native_extension_bindings_system.cc#L579-L585
When `nodejs_enabled` is true, `hidden_nw` is false which enables `nw` and `node` (I believe) in browser context. When `nodejs_enabled` is false, `hidden_nw` is true which disables `nw`.

https://github.com/nwjs/chromium.src/blob/nw75/extensions/renderer/native_extension_bindings_system.cc#L157-L176
I wasn't able to understand too much of whats happening in the `GetOrCreateChrome` function (also noticed the upstream behaviour has been changed for NW.js).

Setting `hidden=false` seemed to resolve the issue.