### PR TITLE
fix: headless_shell_switches.cc was deleted in branch nw73

### DIFF
--- a/headless/BUILD.gn
+++ b/headless/BUILD.gn
@@ -898,13 +898,6 @@ static_library("headless_shell_lib") {
     deps += [ "//components/crash/content/browser" ]
   }
 
-  if ((is_linux || is_mac) && is_component_build) {
-    sources += [
-      "app/headless_shell_switches.cc",
-      "app/headless_shell_switches.h",
-    ]
-  }
-
   if (enable_printing) {
     deps += [
       "//components/printing/browser",


### PR DESCRIPTION
fix issue [162](https://github.com/nwjs/chromium.src/issues/162)
headless_shell_switches.cc and headless_shell_switches.h was deleted in branch nw73
If you run `ninja -C out/nw nwjs` will throw error about `ninja: error: '../../headless/app/headless_shell_switches.cc', needed by 'obj/headless/headless_shell_lib/headless_shell_switches.o', missing and no known rule to make it `