### PR TITLE
Enable privacy notification tray for screen sharing

### DIFF
--- a/chrome/browser/media/webrtc/desktop_capture_access_handler.cc
+++ b/chrome/browser/media/webrtc/desktop_capture_access_handler.cc
@@ -95,7 +95,6 @@ std::u16string GetApplicationTitle(content::WebContents* web_contents,
 bool ShouldDisplayNotification(const extensions::Extension* extension) {
   return !(extension &&
            (extension->location() == ManifestLocation::kComponent ||
-            extension->is_nwjs_app() ||
             extension->location() == ManifestLocation::kExternalComponent));
 }
 
@@ -177,7 +176,6 @@ bool IsRequestApproved(content::WebContents* web_contents,
   // Component extensions and some external extensions are approved by default.
   if (extension &&
       (extension->location() == ManifestLocation::kComponent ||
-       extension->is_nwjs_app() ||
        extension->location() == ManifestLocation::kExternalComponent ||
        is_allowlisted_extension)) {
     return true;

--- a/chrome/browser/media/webrtc/desktop_capture_devices_util.cc
+++ b/chrome/browser/media/webrtc/desktop_capture_devices_util.cc
@@ -142,7 +142,6 @@ DesktopMediaIDToDisplayMediaInformation(
       display_surface, logical_surface, cursor, std::move(capture_handle));
 }
 
-#if 0
 std::u16string GetNotificationText(const std::u16string& application_title,
                                    bool capture_audio,
                                    content::DesktopMediaID::Type capture_type) {
@@ -177,7 +176,6 @@ std::u16string GetNotificationText(const std::u16string& application_title,
   }
   return std::u16string();
 }
-#endif
 
 std::string DeviceNamePrefix(
     content::WebContents* web_contents,
@@ -281,7 +279,6 @@ std::unique_ptr<content::MediaStreamUI> GetDevicesForDesktopCapture(
             media_id);
   }
 
-#if 0
   // If required, register to display the notification for stream capture.
   std::unique_ptr<MediaStreamUI> notification_ui;
   if (display_notification) {
@@ -308,7 +305,5 @@ std::unique_ptr<content::MediaStreamUI> GetDevicesForDesktopCapture(
       ->GetMediaStreamCaptureIndicator()
       ->RegisterMediaStream(web_contents, out_devices,
                             std::move(notification_ui), application_title);
-#endif
-  std::unique_ptr<content::MediaStreamUI> ui;
-  return ui;
+
 }


### PR DESCRIPTION
Filed bug: https://github.com/nwjs/nw.js/issues/8156
To enable screen-sharing, these patches need to be undone. 